### PR TITLE
fix(#138): Fix href for sbom download

### DIFF
--- a/ui/src/app/components/Pages/Generations/GenerationPageContent.tsx
+++ b/ui/src/app/components/Pages/Generations/GenerationPageContent.tsx
@@ -271,7 +271,7 @@ const GenerationPageContent: React.FunctionComponent = () => {
                     return (
                       <a
                         key={index}
-                        href="#"
+                        href={url}
                         onClick={(e) => {
                           e.preventDefault();
                           downloadFileWithCustomName(url, downloadFilename);
@@ -301,7 +301,7 @@ const GenerationPageContent: React.FunctionComponent = () => {
                     return (
                       <a
                         key={index}
-                        href="#"
+                        href={url}
                         onClick={(e) => {
                           e.preventDefault();
                           downloadFileWithCustomName(url, downloadFilename);


### PR DESCRIPTION
In this commit:
  * Use url for href field