### PR TITLE
chore: Bump nginx base container version

### DIFF
--- a/images/sbomer-ui/Containerfile
+++ b/images/sbomer-ui/Containerfile
@@ -1,6 +1,5 @@
-# https://catalog.redhat.com/software/containers/ubi9/nginx-120/61a609f2bfd4a5234d596287
-FROM registry.access.redhat.com/ubi9/nginx-120@sha256:538b6b41585861b6143957aa1dd77e78ae3591fd5a43457fda3a2a51ea11cace
-
+#https://catalog.redhat.com/en/software/containers/ubi9/nginx-120/61a609f2bfd4a5234d596287
+FROM registry.access.redhat.com/ubi9/nginx-120:9.8
 COPY ui/dist/ .
 COPY images/sbomer-ui/run-with-env.sh /deployments/run-with-env.sh
 


### PR DESCRIPTION
In this commit:
  * Bump container image to 1.20
  * Follow 9.8 stream